### PR TITLE
Reply depedency

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,15 +40,10 @@ server.register({
           done(null, results.first + results.second);
         }],
         // make your method depend on 'request' to access the request object:
-        fourth: ['third', 'request', (results, done) => {
+        fourth: ['third', 'request', 'reply', (results, done) => {
           // results.request is now the request object:
-          done(null, results.third + results.request.params.theInput)
-        }]
-        // name a method 'reply' to send its output to the handler's 'reply' method:
-        reply: ['fourth', (results, done) => {
-          const replyString = 'Result was: ' + results.fourth;
-          // send the results back to the caller, same as calling 'reply(replyString)':
-          done(null, replyString);
+          reply(null, results.third + results.request.params.theInput)
+          done();
         }]
       }
     }
@@ -72,27 +67,22 @@ server.register({
     handler: {
       // hapi-auto-handler recognizes the 'autoInject' keyname and will generate the route handler for you:
       autoInject: {
-        first: (done) => {
+        first(done) {
           done(null, 'first');
         },
-        second: (done) => {
+        second(done) {
           done(null, 'second');
         },
         // third only runs after first and second are done:
-        third: (first, second, done) => {
+        third(first, second, done) {
           done(null, first + second);
         },
         // make your method depend on 'request' to access the request object:
-        fourth: (third, request, done) => {
+        final(third, request, reply, done) {
           // request is now the request object:
-          done(null, third + request.params.theInput)
-        },
-        // name a method 'reply' to send its output to the handler's 'reply' method:
-        reply: (fourth, done) => {
-          const replyString = 'Result was: ' + fourth;
-          // send the results back to the caller, same as calling 'reply(replyString)':
-          done(null, replyString);
-        }]
+          reply(null, third + request.params.theInput);
+          done();
+        }
       }
     }
   });
@@ -131,13 +121,13 @@ server.register({
   ...
 ```
 
-### Special Methods
-- ***reply***: if a method in the auto map is given the keyname 'reply', then the result will be forwarded to the route handler's __[reply](http://hapijs.com/api#replyerr-result)__ method.
+- ***reply***: can be specified in the dependency list for a method. Anything passed to that gets send back to the client.
 ```js
 ...
-  reply: (done) => {
+  finished(reply, done) => {
     // this route will always respond with "Hello World!"
-    done(null, "Hello World!");
+    reply(null, "Hello World!");
+    done();
   }
   ...
 ```

--- a/index.js
+++ b/index.js
@@ -20,6 +20,9 @@ exports.register = (server, options, next) => {
       autoOptions.settings = (done) => {
         done(null, request.server.settings.app);
       };
+      autoOptions.reply = (done) => {
+        done(null, reply);
+      };
       // run the async.auto or autoInject expression:
       autoMethod(autoOptions, (err, results) => {
         if (err) {
@@ -34,27 +37,6 @@ exports.register = (server, options, next) => {
           }
           return reply(err).code(500);
         }
-        if (autoOptions.reply) {
-          const replyObj = reply(results.reply);
-          if (results.redirect) {
-            replyObj.redirect(results.redirect);
-          }
-          if (results.setState) {
-            const name = results.setState.name;
-            const data = results.setState.data;
-            replyObj.state(name, data);
-          }
-          if (results.setHeaders) {
-            Object.keys(results.setHeaders).forEach((key) => {
-              replyObj.header(key, results.setHeaders[key]);
-            });
-          }
-          return replyObj;
-        }
-        // must unset these before hapi can return the results object:
-        unset(results, 'server');
-        unset(results, 'request');
-        reply(results);
       });
     };
 

--- a/index.js
+++ b/index.js
@@ -7,9 +7,9 @@ const defaults = {};
 
 exports.register = (server, options, next) => {
   options = defaultMethod(options, defaults);
-  const getReplyHandler = (autoMethod, autoOptions) =>
-    (request, reply) => {
-      let legacy = true;
+  const getReplyHandler = (autoMethod, autoOptions) => {
+    const legacy = (autoOptions.reply);
+    return (request, reply) => {
       // a copy of the server is available within the auto methods as results.server:
       autoOptions.server = (done) => {
         done(null, server.root);
@@ -21,8 +21,7 @@ exports.register = (server, options, next) => {
       autoOptions.settings = (done) => {
         done(null, request.server.settings.app);
       };
-      if (!autoOptions.reply) {
-        legacy = false;
+      if (!legacy) {
         autoOptions.reply = (done) => {
           done(null, reply);
         };
@@ -68,6 +67,7 @@ exports.register = (server, options, next) => {
         reply(results);
       });
     };
+  };
 
   // define an 'auto' handler that routes can use:
   server.handler('auto', (route, autoOptions) => getReplyHandler(async.auto, autoOptions));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hapi-auto-handler",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "Hapi plugin, provides syntactic sugar to make it easy to define async.auto workflows in your handlers",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,6 @@
     "eslint-config-firstandthird": "^3.1.0",
     "eslint-plugin-import": "^2.1.0",
     "hapi": "^16.0.2",
-    "lab": "^11.2.1"
+    "lab": "13.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hapi-auto-handler",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Hapi plugin, provides syntactic sugar to make it easy to define async.auto workflows in your handlers",
   "main": "index.js",
   "scripts": {

--- a/test/test.plugin.js
+++ b/test/test.plugin.js
@@ -4,7 +4,7 @@ const Lab = require('lab');
 const lab = exports.lab = Lab.script();
 const Hapi = require('hapi');
 const autoPlugin = require('../');
-//const Boom = require('boom');
+const Boom = require('boom');
 
 lab.experiment('hapi-auto-handler', () => {
   let server;
@@ -47,7 +47,6 @@ lab.experiment('hapi-auto-handler', () => {
     });
   });
 
-/*
   lab.test(' allows a basic auto handler', (allDone) => {
     const calledStatements = [];
     server.register({
@@ -70,6 +69,9 @@ lab.experiment('hapi-auto-handler', () => {
             third: ['first', 'second', (results, done) => {
               calledStatements.push('third');
               done(null, 'the_third_result');
+            }],
+            reply: ['first', 'second', 'third', (results, done) => {
+              done(null, results);
             }]
           }
         }
@@ -230,6 +232,9 @@ lab.experiment('hapi-auto-handler', () => {
             }],
             third: ['first', 'second', (results, done) => {
               done(null, 'the_third_result');
+            }],
+            reply: ['first', 'second', 'third', (results, done) => {
+              done(null, results);
             }]
           }
         }
@@ -478,5 +483,4 @@ lab.experiment('hapi-auto-handler', () => {
       });
     });
   });
-  */
 });

--- a/test/test.plugin.js
+++ b/test/test.plugin.js
@@ -4,7 +4,7 @@ const Lab = require('lab');
 const lab = exports.lab = Lab.script();
 const Hapi = require('hapi');
 const autoPlugin = require('../');
-const Boom = require('boom');
+//const Boom = require('boom');
 
 lab.experiment('hapi-auto-handler', () => {
   let server;
@@ -21,6 +21,33 @@ lab.experiment('hapi-auto-handler', () => {
     done();
   });
 
+  lab.test('pass in reply obj', (allDone) => {
+    server.register({
+      register: autoPlugin,
+      options: {}
+    }, () => {
+      server.route({
+        path: '/',
+        method: 'GET',
+        handler: {
+          autoInject: {
+            run(reply, done) {
+              reply.redirect('/redirect');
+              done();
+            }
+          }
+        }
+      });
+      server.start(() => {
+        server.inject('/', (response) => {
+          code.expect(response.statusCode).to.equal(302);
+          allDone();
+        });
+      });
+    });
+  });
+
+/*
   lab.test(' allows a basic auto handler', (allDone) => {
     const calledStatements = [];
     server.register({
@@ -451,4 +478,5 @@ lab.experiment('hapi-auto-handler', () => {
       });
     });
   });
+  */
 });

--- a/test/test.plugin.js
+++ b/test/test.plugin.js
@@ -11,7 +11,8 @@ lab.experiment('hapi-auto-handler', () => {
   lab.beforeEach((done) => {
     server = new Hapi.Server({
       debug: {
-        log: ['warning']
+        log: ['warning'],
+        //request: ['error']
       },
       app: {
         key: 'value'
@@ -21,31 +22,6 @@ lab.experiment('hapi-auto-handler', () => {
     done();
   });
 
-  lab.test('pass in reply obj', (allDone) => {
-    server.register({
-      register: autoPlugin,
-      options: {}
-    }, () => {
-      server.route({
-        path: '/',
-        method: 'GET',
-        handler: {
-          autoInject: {
-            run(reply, done) {
-              reply.redirect('/redirect');
-              done();
-            }
-          }
-        }
-      });
-      server.start(() => {
-        server.inject('/', (response) => {
-          code.expect(response.statusCode).to.equal(302);
-          allDone();
-        });
-      });
-    });
-  });
 
   lab.test(' allows a basic auto handler', (allDone) => {
     const calledStatements = [];
@@ -71,7 +47,7 @@ lab.experiment('hapi-auto-handler', () => {
               done(null, 'the_third_result');
             }],
             reply: ['first', 'second', 'third', (results, done) => {
-              done(null, results);
+              done(null, { third: results.third });
             }]
           }
         }
@@ -234,7 +210,7 @@ lab.experiment('hapi-auto-handler', () => {
               done(null, 'the_third_result');
             }],
             reply: ['first', 'second', 'third', (results, done) => {
-              done(null, results);
+              done(null, { first: results.first, second: results.second, third: results.third });
             }]
           }
         }
@@ -478,6 +454,32 @@ lab.experiment('hapi-auto-handler', () => {
         server.inject('/example', (res) => {
           code.expect(res.headers['content-type'], 'application/mp3');
           code.expect(res.statusCode).to.equal(200);
+          allDone();
+        });
+      });
+    });
+  });
+
+  lab.test('pass in reply obj', (allDone) => {
+    server.register({
+      register: autoPlugin,
+      options: {}
+    }, () => {
+      server.route({
+        path: '/',
+        method: 'GET',
+        handler: {
+          autoInject: {
+            run(reply, done) {
+              reply.redirect('/redirect');
+              done();
+            }
+          }
+        }
+      });
+      server.start(() => {
+        server.inject('/', (response) => {
+          code.expect(response.statusCode).to.equal(302);
           allDone();
         });
       });


### PR DESCRIPTION
This gives us complete control over the reply object.  So we can set redirects, cookies, views, etc.  Instead of having a reply method, we just inject the reply as a dependency.  I've made the change backwards compatible, but I think we should call reply directly moving forward because we get finer grained control.  Let me know if anybody sees any scenarios that will break with this change

@dawnerd @ecwillis @orthagonal 